### PR TITLE
Make CanvasManager persist the next Painting ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User-specific stuff
 .idea/
+.vscode/
 
 *.iml
 *.ipr
@@ -102,6 +103,8 @@ $RECYCLE.BIN/
 
 .gradle
 build/
+bin/
+remappedSrc/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
The next painting ID is being tracked but not persisted after a reload. This results in new canvases appearing as existing paintings instead of empty ones, after a restart. Marking the CanvasManager as dirty after each increment of the next painting ID might fix this. Wrote this on my Android after having an epiphany. Testing tomorrow, hence the draft. Love the mod! Looking forward to contributing this smol patch.